### PR TITLE
feat(daydream): support goal, multiple concepts

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,5 @@ Here are the setup details for my laptops.
 - [viz.py](viz.py) embeds CSV files a HTML templates. This is the script that started [Gramener](http://gramener.com/) in 2011.
 - [rofi-files.sh](rofi-files.sh) and [rofi-chrome-tabs.sh](rofi-chrome-tabs.sh) are used by rofi to get recent files.
 - [generate/](generate/) has scripts to generate data.
+- [daydream](daydream) fuses recalled concepts into radical ideas. Example: `daydream -c llm -c oblique-strategies "web app"`
+- [recall](recall) shows a random note bullet. Example: `recall` or `recall talks`

--- a/daydream
+++ b/daydream
@@ -52,15 +52,14 @@ fi
 
 # 1. Fetch concepts
 # concept_terms holds recall prompts; concepts holds retrieved text
+while ((${#concept_terms[@]} < 2)); do
+    concept_terms+=("@llm @til core-concepts")
+done
+
 declare -a concepts=()
-if [[ ${#concept_terms[@]} -eq 0 ]]; then
-    concepts+=("$(recall @llm @til core-concepts --no-source)")
-    concepts+=("$(recall @llm @til core-concepts --no-source)")
-else
-    for t in "${concept_terms[@]}"; do
-        concepts+=("$(recall "$t" --no-source --decay=0)")
-    done
-fi
+for t in "${concept_terms[@]}"; do
+    concepts+=("$(recall "$t" --no-source --decay=0)")
+done
 
 # 2. Build multiline prompt
 CONCEPTS="<GOAL>${goal}</GOAL>"

--- a/daydream
+++ b/daydream
@@ -137,7 +137,6 @@ CRITICAL: If you can't identify significant weaknesses or alternatives, you're b
 json=$(printf '%s' "$EVAL" \
   | jq -c \
       --argjson concepts "$(printf '%s\n' "${concepts[@]}" | jq -R . | jq -s .)" \
-      # convert bash array -> JSON array
       --arg goal "$goal" \
       --arg idea "$IDEA" \
       --arg timestamp "$(date -Iseconds)" \

--- a/daydream
+++ b/daydream
@@ -58,7 +58,7 @@ done
 
 declare -a concepts=()
 for t in "${concept_terms[@]}"; do
-    concepts+=("$(recall "$t" --no-source --decay=0)")
+    concepts+=("$(recall $t --no-source --decay=0)")
 done
 
 # 2. Build multiline prompt

--- a/daydream
+++ b/daydream
@@ -8,6 +8,8 @@ set -euo pipefail
 
 # Parse command line arguments
 mode="generate" # Default mode
+goal=""
+declare -a concept_terms=()
 while [[ $# -gt 0 ]]; do
     case "$1" in
         # --random shows a random row
@@ -19,7 +21,20 @@ while [[ $# -gt 0 ]]; do
             n=${1:-1}  # Default to 1 if no number provided
             [[ "$n" =~ ^[0-9]+$ ]] && shift || n=1  # Shift only if it was a number
             ;;
-        *) echo "Unknown parameter: $1"; exit 1 ;;
+        -c|--concept)
+            shift
+            concept_terms+=("$1")
+            shift
+            ;;
+        -*) echo "Unknown parameter: $1"; exit 1 ;;
+        *)
+            if [[ -z "$goal" ]]; then
+                goal="$1"
+                shift
+            else
+                echo "Unknown parameter: $1"; exit 1
+            fi
+            ;;
     esac
 done
 
@@ -35,21 +50,23 @@ if [[ "$mode" == "latest" ]]; then
     exit 0
 fi
 
-# 1. Fetch two core-concepts
-CONCEPT1=$(recall @llm @til core-concepts --no-source)
-CONCEPT2=$(recall @llm @til core-concepts --no-source)
+# 1. Fetch concepts
+# concept_terms holds recall prompts; concepts holds retrieved text
+declare -a concepts=()
+if [[ ${#concept_terms[@]} -eq 0 ]]; then
+    concepts+=("$(recall @llm @til core-concepts --no-source)")
+    concepts+=("$(recall @llm @til core-concepts --no-source)")
+else
+    for t in "${concept_terms[@]}"; do
+        concepts+=("$(recall "$t" --no-source --decay=0)")
+    done
+fi
 
 # 2. Build multiline prompt
-CONCEPTS=$(cat <<EOF
-<CONCEPT1>
-$CONCEPT1
-</CONCEPT1>
-
-<CONCEPT2>
-$CONCEPT2
-</CONCEPT2>
-EOF
-)
+CONCEPTS="<GOAL>${goal}</GOAL>"
+for c in "${concepts[@]}"; do
+    CONCEPTS+=$'\n<CONCEPT>\n'"$c"$'\n</CONCEPT>'
+done
 
 # 3. Show it
 echo "$CONCEPTS"
@@ -57,10 +74,10 @@ echo "$CONCEPTS"
 # 4. Generate idea (stream + capture)
 IDEA=$(llm --model o4-mini --system "You are a radical concept synthesiser hired to astound even experts.
 
-GOAL: Generate one radically non-obvious idea fusing CONCEPT 1 and CONCEPT 2, with concrete next steps.
+GOAL: Generate one radically non-obvious <GOAL>-aligned idea fusing provided <CONCEPT>s with concrete next steps.
 
 THINK:
-1. Generate 5+ candidate links using these lenses: Inversion, Mechanism-transplant, Constraint-violation, Scale-jump, Any other radical angle
+1. Generate 5+ candidate links using these lenses: Inversion, Mechanism-transplant, Constraint-violation, Scale-jump, Oblique strategies, Any other radical angle
 2. Score for Novelty x Utility (1-5 each); select the highest-scoring fusion
 3. Converge: stress-test for edge-cases; refine language.
 
@@ -120,13 +137,14 @@ CRITICAL: If you can't identify significant weaknesses or alternatives, you're b
 # 6. Merge into one JSON line and append
 json=$(printf '%s' "$EVAL" \
   | jq -c \
-      --arg concept1 "$CONCEPT1" \
-      --arg concept2 "$CONCEPT2" \
+      --argjson concepts "$(printf '%s\n' "${concepts[@]}" | jq -R . | jq -s .)" \
+      # convert bash array -> JSON array
+      --arg goal "$goal" \
       --arg idea "$IDEA" \
       --arg timestamp "$(date -Iseconds)" \
     '. + {
-        concept1:$concept1,
-        concept2:$concept2,
+        concepts:$concepts,
+        goal:$goal,
         idea:$idea,
         timestamp:$timestamp
       }'

--- a/recall
+++ b/recall
@@ -28,13 +28,14 @@ const term = terms[Math.floor(Math.random() * terms.length)];
 const re = new RegExp(term, "i");
 
 const HOME = Deno.env.get("HOME") ?? Deno.env.get("USERPROFILE") ?? "";
-const DIR = `${HOME}/Dropbox/notes`;
+const DIRS = [`${HOME}/Dropbox/notes`, `${HOME}/Dropbox/notes/about`];
 
 // pick newest matching .md file
 const files = [];
-for await (const e of Deno.readDir(DIR))
-  if (e.isFile && e.name.endsWith(".md") && re.test(e.name))
-    files.push({ path: `${DIR}/${e.name}`, mtime: (await Deno.stat(`${DIR}/${e.name}`)).mtime?.getTime() || 0 });
+for (const DIR of DIRS)
+  for await (const e of Deno.readDir(DIR))
+    if (e.isFile && e.name.endsWith(".md") && re.test(e.name))
+      files.push({ path: `${DIR}/${e.name}`, mtime: (await Deno.stat(`${DIR}/${e.name}`)).mtime?.getTime() || 0 });
 
 files.sort((a, b) => b.mtime - a.mtime);
 const txt = await Deno.readTextFile(files[0].path);


### PR DESCRIPTION
## Summary
- allow multiple `-c` or `--concept` flags
- accept goal string argument
- inject concepts and goal into prompt
- store `concepts` array and goal in output JSON

## Testing
- `npx -y prettier@3.5 --print-width=120 '**/*.js' '**/*.md'`
- `npx -y js-beautify@1 '**/*.html' --type html --replace --indent-size 2 --max-preserve-newlines 1 --end-with-newline`
- `uvx ruff format --line-length 100 --check .`
- `bash -x ./daydream -c alpha -c "beta gamma" -c delta "web app" | head -n 20`
- `bash -x ./daydream --concept alpha "web app" --concept "beta gamma" -c delta | head -n 20`
- `bash -x ./daydream | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_687af166e3d8832c998cee9bfeceddf1